### PR TITLE
Create patch to update apache/beam/sdks from 2.46.0 to 2.50.0 in differential_privacy

### DIFF
--- a/third_party/beam_differential_privacy.patch
+++ b/third_party/beam_differential_privacy.patch
@@ -1,0 +1,29 @@
+diff --git a/privacy-on-beam/go.mod b/privacy-on-beam/go.mod
+index 2aa5b16..51ce317 100644
+--- a/privacy-on-beam/go.mod
++++ b/privacy-on-beam/go.mod
+@@ -3,7 +3,7 @@ module github.com/google/differential-privacy/privacy-on-beam/v2
+ go 1.19
+ 
+ require (
+-	github.com/apache/beam/sdks/v2 v2.46.0
++	github.com/apache/beam/sdks/v2 v2.50.0
+ 	github.com/golang/glog v1.1.1
+ 	github.com/google/differential-privacy/go/v2 v2.1.0
+ 	github.com/google/go-cmp v0.5.9
+diff --git a/privacy-on-beam/go.sum b/privacy-on-beam/go.sum
+index adf45d6..870b876 100644
+--- a/privacy-on-beam/go.sum
++++ b/privacy-on-beam/go.sum
+@@ -5,8 +5,8 @@ github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm
+ github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
+ github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b h1:slYM766cy2nI3BwyRiyQj/Ud48djTMtMebDqepE95rw=
+ github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b/go.mod h1:1KcenG0jGWcpt8ov532z81sp/kMMUG485J2InIOyADM=
+-github.com/apache/beam/sdks/v2 v2.46.0 h1:CkssanJ42U1yHj86XAfUrNQEc2G2/O+vu9IK1OIG5iQ=
+-github.com/apache/beam/sdks/v2 v2.46.0/go.mod h1:C4oJu53POCMwZT0hdeDjHrIMWsN1OEQasF2n8+e8SVo=
++github.com/apache/beam/sdks/v2 v2.50.0 h1:5/VM4TPRBk8KKU3t/nKWIUGbNiLZRMusFPxtMY8Op4w=
++github.com/apache/beam/sdks/v2 v2.50.0/go.mod h1:l8zcwQ8ZBMI1zgvA/iI9k9+EaapvAchruwtT1Jxz/ow=
+ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+ github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+ github.com/frankban/quicktest v1.2.2 h1:xfmOhhoH5fGPgbEAlhLpJH9p0z/0Qizio9osmvn9IUY=
+

--- a/third_party/cpp_deps.bzl
+++ b/third_party/cpp_deps.bzl
@@ -148,6 +148,8 @@ def cpp_dependencies():
         name = "com_google_differential_privacy",
         sha256 = "161ae3676b7c75bb948a58c81bc982e5be4922f4ca7438237d8439857c42c640",
         strip_prefix = "differential-privacy-2.1.0",
+        patch_args = ["-p1"],
+        patches = [Label("//third_party:beam_differential_privacy.patch")],
         urls = ["https://github.com/google/differential-privacy/archive/refs/tags/v2.1.0.zip"],
     )
     maybe(


### PR DESCRIPTION
A security issue was discovered in docker in 2018, where an attacker could bypass AuthZ plugins using a specially crafted API request. This could lead to unauthorized actions, including privilege escalation.  A fix was landed in docker 23.0.15

apache/beam/sdks 2.46.0 was dependent on an outdated version of docker.  In [this commit on July 27th, 2023](https://github.com/apache/beam/commit/5a54ee6ddd8cb8444c41802929a364fe2561001e#diff-9cb02220b2e69ab013af96c5868b8d502e2413f9ec1bf2df7898bc77436a9a02) , the version of docker was update from 23.0.5 to 24.0.5, which should include the required fix.  That fix was released in apache/beam/sdks 2.50.0

This PR increments apache/beam/sdks from 2.46.0 to 2.50.0 to address the security concern.