### PR TITLE
Create patch to update protobufjs from 7.1.2 to 7.4.0 in rules_proto_grpc

### DIFF
--- a/third_party/deps2.bzl
+++ b/third_party/deps2.bzl
@@ -73,6 +73,8 @@ def _proto_deps():
     maybe(
         http_archive,
         name = "rules_proto_grpc",
+        patch_args = ["-p1"],
+        patches = [Label("//third_party:rules_proto_grpc.patch")],
         sha256 = "a53cea895b9e870cdcfe5e50a1c61d8aa837c1d30b5886b210f0eb3e4709e4bc",
         strip_prefix = "rules_proto_grpc-4.6.0",
         urls = [

--- a/third_party/rules_proto_grpc.patch
+++ b/third_party/rules_proto_grpc.patch
@@ -1,0 +1,151 @@
+diff --git a/js/requirements/package.json b/js/requirements/package.json
+index 0e23b548..9f094a4f 100644
+--- a/js/requirements/package.json
++++ b/js/requirements/package.json
+@@ -1,6 +1,6 @@
+ {
+   "dependencies": {
+-    "@grpc/grpc-js": "1.7.3",
++    "@grpc/grpc-js": "^1.12.4",
+     "google-protobuf": "3.21.2",
+     "grpc-tools": "1.11.3",
+     "grpc-web": "1.4.2",
+diff --git a/js/requirements/yarn.lock b/js/requirements/yarn.lock
+index d18ac834..06d304c5 100644
+--- a/js/requirements/yarn.lock
++++ b/js/requirements/yarn.lock
+@@ -2,24 +2,28 @@
+ # yarn lockfile v1
+ 
+ 
+-"@grpc/grpc-js@1.7.3":
+-  version "1.7.3"
+-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.7.3.tgz#f2ea79f65e31622d7f86d4b4c9ae38f13ccab99a"
+-  integrity sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==
++"@grpc/grpc-js@^1.12.4":
++  version "1.12.4"
++  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.12.4.tgz#3208808435ebf1e495f9a5c5c5a0bc3dc8c9e891"
++  integrity sha512-NBhrxEWnFh0FxeA0d//YP95lRFsSx2TNLEUQg4/W+5f/BMxcCjgOOIT24iD+ZB/tZw057j44DaIxja7w4XMrhg==
+   dependencies:
+-    "@grpc/proto-loader" "^0.7.0"
+-    "@types/node" ">=12.12.47"
++    "@grpc/proto-loader" "^0.7.13"
++    "@js-sdsl/ordered-map" "^4.4.2"
+ 
+-"@grpc/proto-loader@^0.7.0":
+-  version "0.7.3"
+-  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.3.tgz#75a6f95b51b85c5078ac7394da93850c32d36bb8"
+-  integrity sha512-5dAvoZwna2Py3Ef96Ux9jIkp3iZ62TUsV00p3wVBPNX5K178UbNi8Q7gQVqwXT1Yq9RejIGG9G2IPEo93T6RcA==
++"@grpc/proto-loader@^0.7.13":
++  version "0.7.13"
++  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.13.tgz#f6a44b2b7c9f7b609f5748c6eac2d420e37670cf"
++  integrity sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==
+   dependencies:
+-    "@types/long" "^4.0.1"
+     lodash.camelcase "^4.3.0"
+-    long "^4.0.0"
+-    protobufjs "^7.0.0"
+-    yargs "^16.2.0"
++    long "^5.0.0"
++    protobufjs "^7.2.5"
++    yargs "^17.7.2"
++
++"@js-sdsl/ordered-map@^4.4.2":
++  version "4.4.2"
++  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
++  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
+ 
+ "@mapbox/node-pre-gyp@^1.0.5":
+   version "1.0.10"
+@@ -89,12 +93,7 @@
+   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
+ 
+-"@types/long@^4.0.1":
+-  version "4.0.2"
+-  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
+-  integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
+-
+-"@types/node@>=12.12.47", "@types/node@>=13.7.0":
++"@types/node@>=13.7.0":
+   version "18.11.9"
+   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
+   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
+@@ -154,13 +153,13 @@ chownr@^2.0.0:
+   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+ 
+-cliui@^7.0.2:
+-  version "7.0.4"
+-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+-  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
++cliui@^8.0.1:
++  version "8.0.1"
++  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
++  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+   dependencies:
+     string-width "^4.2.0"
+-    strip-ansi "^6.0.0"
++    strip-ansi "^6.0.1"
+     wrap-ansi "^7.0.0"
+ 
+ color-convert@^2.0.1:
+@@ -314,11 +313,6 @@ lodash.camelcase@^4.3.0:
+   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+   integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
+ 
+-long@^4.0.0:
+-  version "4.0.0"
+-  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+-  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+-
+ long@^5.0.0:
+   version "5.2.1"
+   resolved "https://registry.yarnpkg.com/long/-/long-5.2.1.tgz#e27595d0083d103d2fa2c20c7699f8e0c92b897f"
+@@ -411,10 +405,10 @@ path-is-absolute@^1.0.0:
+   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
+ 
+-protobufjs@^7.0.0:
+-  version "7.1.2"
+-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.1.2.tgz#a0cf6aeaf82f5625bffcf5a38b7cd2a7de05890c"
+-  integrity sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==
++protobufjs@^7.2.5:
++  version "7.4.0"
++  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.4.0.tgz#7efe324ce9b3b61c82aae5de810d287bc08a248a"
++  integrity sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==
+   dependencies:
+     "@protobufjs/aspromise" "^1.1.2"
+     "@protobufjs/base64" "^1.1.2"
+@@ -573,20 +567,20 @@ yallist@^4.0.0:
+   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+ 
+-yargs-parser@^20.2.2:
+-  version "20.2.9"
+-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
++yargs-parser@^21.1.1:
++  version "21.1.1"
++  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
++  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+ 
+-yargs@^16.2.0:
+-  version "16.2.0"
+-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+-  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
++yargs@^17.7.2:
++  version "17.7.2"
++  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
++  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+   dependencies:
+-    cliui "^7.0.2"
++    cliui "^8.0.1"
+     escalade "^3.1.1"
+     get-caller-file "^2.0.5"
+     require-directory "^2.1.1"
+-    string-width "^4.2.0"
++    string-width "^4.2.3"
+     y18n "^5.0.5"
+-    yargs-parser "^20.2.2"
++    yargs-parser "^21.1.1"


### PR DESCRIPTION
A security issue was discovered in protobuf.js in 6.10.0 until 6.11.4 and 7.0.0 until 7.2.4, where a user-controlled protobuf message can be used by an attacker to pollute the prototype of Object.prototype by adding and overwriting its data and functions. Exploitation can involve: (1) using the function parse to parse protobuf messages on the fly, (2) loading .proto files by using load/loadSync functions, or (3) providing untrusted input to the functions ReflectionObject.setParsedOption and util.setProperty

grpc/grpc-js 1.7.3 was dependent on an outdated version of protobuf.js. By incrementing grpc/grpc-js from 1.7.3 to 1.12.4, we also increment protobufjs from 7.1.2 to 7.4.0, resolving the security issue.
