### PR TITLE
Modify patch to update google/go-containerregistry from 0.14.0 to 0.16.0 in rules_oci

### DIFF
--- a/third_party/rules_oci.patch
+++ b/third_party/rules_oci.patch
@@ -209,3 +209,32 @@ index 1cdf45a..2373844 100644
  
      return manifest, len(bytes), digest
  
+diff --git e2e/assertion/registry/go.mod e2e/assertion/registry/go.mod
+index e7feb08..2edef80 100644
+--- e2e/assertion/registry/go.mod
++++ e2e/assertion/registry/go.mod
+@@ -3,7 +3,7 @@ module example.com/auth
+ go 1.19
+ 
+ require (
+-	github.com/google/go-containerregistry v0.14.0
++	github.com/google/go-containerregistry v0.16.0
+ 	github.com/r3labs/diff/v3 v3.0.1
+ )
+ 
+diff --git e2e/assertion/registry/go.sum e2e/assertion/registry/go.sum
+index d21afe1..4e8f84b 100644
+--- e2e/assertion/registry/go.sum
++++ e2e/assertion/registry/go.sum
+@@ -6,8 +6,8 @@ github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6
+ github.com/docker/docker v23.0.1+incompatible h1:vjgvJZxprTTE1A37nm+CLNAdwu6xZekyoiVlUZEINcY=
+ github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
+ github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+-github.com/google/go-containerregistry v0.14.0 h1:z58vMqHxuwvAsVwvKEkmVBz2TlgBgH5k6koEXBtlYkw=
+-github.com/google/go-containerregistry v0.14.0/go.mod h1:aiJ2fp/SXvkWgmYHioXnbMdlgB8eXiiYOY55gfN91Wk=
++github.com/google/go-containerregistry v0.16.0 h1:p/9fLdmLZ7NPxYZgpgGhPcCCnfKqnB520YVLaJMlPFc=
++github.com/google/go-containerregistry v0.16.0/go.mod h1:u0qB2l7mvtWVR5kNcbFIhFY1hLbf8eeGapA+vbFDCtQ=
+ github.com/klauspost/compress v1.16.0 h1:iULayQNOReoYUe+1qtKOqw9CwJv3aNQu8ivo7lw1HU4=
+ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+ 


### PR DESCRIPTION
A security issue was discovered in docker in 2018, where an attacker could bypass AuthZ plugins using a specially crafted API request. This could lead to unauthorized actions, including privilege escalation. A fix was landed in docker 23.0.15

google/go-containerregistry 0.14.0 was dependent on an outdated version of docker. In [this commit on May 31st](https://github.com/google/go-containerregistry/commit/b7ad3f13a62ce40366707a1347ab4bf33d5cd0d9#diff-990006452889d2adad4dec88886a0b1c2dee87ab79c6b64afa74293457ced2a8R13) , the version of docker was update to 24.0.0, which should include the required fix.  That commit was released in google/go-containerregistry 0.16.0

This PR increments google/go-containerregistry from 0.14.0 to 0.16.0 to address the security concern.